### PR TITLE
Adding step to point your command line to your machine.

### DIFF
--- a/docs/mac/step_one.md
+++ b/docs/mac/step_one.md
@@ -147,9 +147,11 @@ Virtual Box VM, it maintains its configuration between uses.
    1. Type the `docker-machine env default` command and press RETURN.
    2. This will generate some output. The last two lines of output should look like this:
    
- 	# Run this command to configure your shell: 
-	# eval "$(docker-machine env default)"
-
+        ```
+	# Run this command to configure your shell: 
+        # eval "$(docker-machine env default)"
+        ```
+   
    3. Type the `eval "$(docker-machine env default)"` command and press RETURN. 
 
 5. Type the `docker run hello-world` command and press RETURN.

--- a/docs/mac/step_one.md
+++ b/docs/mac/step_one.md
@@ -142,7 +142,17 @@ Virtual Box VM, it maintains its configuration between uses.
     by a highlighted area or a `|` that appears in the command line. After
     typing a command, always press RETURN.
 
-4. Type the `docker run hello-world` command and press RETURN.
+4. Configure your command line to point to your Docker machine
+   
+   1. Type the `docker-machine env default` command and press RETURN.
+   2. This will generate some output. The last two lines of output should look like this:
+   
+ 	# Run this command to configure your shell: 
+	# eval "$(docker-machine env default)"
+
+   3. Type the `eval "$(docker-machine env default)"` command and press RETURN. 
+
+5. Type the `docker run hello-world` command and press RETURN.
 
     The command does some work for you, if everything runs well, the command's
     output looks like this:


### PR DESCRIPTION
I was using the documentation at: http://docs.docker.com/mac/step_one/

After I completed step 2 where I launch the quickstart terminal, I was unable to get "docker run hello-world". Some searching turned up that I needed to run the `docker-machine env default` command and then, after that, paste in the command from that output. I've added the additional step and tried to make sure my formatting followed the other steps in the guide. I hope this helps someone else!