### PR TITLE
Fix formatting of step three point two

### DIFF
--- a/docs/linux/step_six.md
+++ b/docs/linux/step_six.md
@@ -28,12 +28,12 @@ new image.
 
 3. Find the `IMAGE ID` for your `docker-whale` image.
 
-        In this example, the id is `7d9495d03763`.
+    In this example, the id is `7d9495d03763`.
 
-        You'll notice that currently, the `REPOSITORY` shows the repository but not
-        the namespace for `docker-whale`. You need to include the `namespace` for
-        Docker Hub to associate it with your account.  The `namespace` is the same as
-        your account name.
+    You'll notice that currently, the `REPOSITORY` shows the repository but not
+    the namespace for `docker-whale`. You need to include the `namespace` for
+    Docker Hub to associate it with your account.  The `namespace` is the same as
+    your account name.
 
 4. Use `IMAGE ID` and the `docker tag` command to tag your `docker-whale` image.
 

--- a/docs/linux/step_three.md
+++ b/docs/linux/step_three.md
@@ -77,9 +77,9 @@ People all over the world create Docker images. You can find these images by bro
                 \    \        __/
                   \____\______/
 
-        The first time you run a software image, the `docker` command looks for it
-        on your local system. If the image isn't there, then `docker` gets it from
-        the hub.
+    The first time you run a software image, the `docker` command looks for it
+    on your local system. If the image isn't there, then `docker` gets it from
+    the hub.
 
 3. While still in the terminal, type `docker images` command and press RETURN.
 


### PR DESCRIPTION
As reported by Baptiste Darthenay on Twitter

>  https://twitter.com/batisteo/status/660415121957765120
> Baptiste Darthenay ⠵`@batisteo`
> @docker Thx for you great docs! There is a little quirk at the end of point 2 
> https://docs.docker.com/linux/step_three/#step-2-run-the-whalesay-image just under the whale. No pb for Mac.