### PR TITLE
Removing duplicate lines

### DIFF
--- a/docs/linux/step_one.md
+++ b/docs/linux/step_one.md
@@ -70,12 +70,6 @@ target="_blank">repositories instead for your installation</a>.
         For more examples and ideas, visit:
          https://docs.docker.com/userguide/
 
-        To try something more ambitious, you can run an Ubuntu container with:
-         $ docker run -it ubuntu bash
-
-        For more examples and ideas, visit:
-         https://docs.docker.com/userguide/
-
 
 ## Where to go next
 


### PR DESCRIPTION
The documentation has duplicate lines of output compared to the actual output of
the command 'docker run hello-world' (as seen in step 4 of
https://docs.docker.com/linux/step_one/ )

Signed-off-by: Nick Loadholtes <nick@ironboundsoftware.com>

Fixes #53