### PR TITLE
Update install instructions to use cURL

### DIFF
--- a/docs/linux/step_one.md
+++ b/docs/linux/step_one.md
@@ -11,24 +11,24 @@ weight = 1
 
 This installation procedure is written for users who are unfamiliar with package
 managers. If you are comfortable with package managers, prefer not to use
-`wget`, or have problems installing and want to troubleshoot, please use our
+`curl`, or have problems installing and want to troubleshoot, please use our
 `apt` and `yum` <a href="https://docs.docker.com/engine/installation/"
 target="_blank">repositories instead for your installation</a>.
 
 1. Log into your Ubuntu installation as a user with `sudo` privileges.
 
-2. Verify that you have `wget` installed.
+2. Verify that you have `curl` installed.
 
-        $ which wget
+        $ which curl
 
-    If `wget` isn't installed, install it after updating your manager:
+    If `curl` isn't installed, install it after updating your manager:
 
         $ sudo apt-get update
-        $ sudo apt-get install wget
+        $ sudo apt-get install curl 
 
 3. Get the latest Docker package.
 
-        $ wget -qO- https://get.docker.com/ | sh
+        $ curl -fsSL https://get.docker.com/ | sh
 
     The system prompts you for your `sudo` password. Then, it downloads and
     installs Docker and its dependencies.
@@ -38,7 +38,7 @@ target="_blank">repositories instead for your installation</a>.
     >command fails for the Docker repo during installation. To work around this,
     >add the key directly using the following:
     >
-    >       $ wget -qO- https://get.docker.com/gpg | sudo apt-key add -
+    >       $ curl -fsSL https://get.docker.com/gpg | sudo apt-key add -
 
 4. Verify `docker` is installed correctly.
 


### PR DESCRIPTION
To be consistent with other installation docs, ref: https://github.com/docker/docker/issues/14650#issuecomment-169169157.

Also added the `-f` flag to the curl instructions, which prevents some issues if get.docker.com is not reachable or blocked (per @tianon's comment: https://github.com/docker/docker/pull/15409#issuecomment-169171846).
